### PR TITLE
Lost packet logic + Mark End Game Fix

### DIFF
--- a/src/game_container/GameContainer.h
+++ b/src/game_container/GameContainer.h
@@ -42,6 +42,8 @@ namespace GetgudSDK {
 		unsigned int GetAverageSizeInBytes();
 		GameData* PopNextGameToProcess();
 		bool MarkEndGame(std::string gameGuid);
+		void SentGameMarkedAsEnded(std::string gameGuid);
+		void MarkGameMatchesAsNotInteresting(std::string gameGuid, std::vector<std::string>& matchGuids);
 		bool SetMatchWinTeam(std::string matchGuid, std::string teamGuid);
 		bool DeleteGame(std::string gameGuid, bool externalCall);
 		void Dispose();

--- a/src/game_container/GameData.cpp
+++ b/src/game_container/GameData.cpp
@@ -81,10 +81,7 @@ namespace GetgudSDK {
 		cloneGameData->m_sizeInBytes = m_sizeInBytes;
 		cloneGameData->m_startGameTimer = m_startGameTimer;
 		cloneGameData->m_lastUpdateTime = m_lastUpdateTime;
-
-		// whenever a game is cloned it means it's going to be sent to the server, 
-		// thus if m_isGameMarkedAsEnded is true it means m_sentGameMarkedAsEnded should chnage to true as well -> both in the cloned game and original game
-		cloneGameData->m_sentGameMarkedAsEnded = m_sentGameMarkedAsEnded = m_isGameMarkedAsEnded;
+		cloneGameData->m_sentGameMarkedAsEnded = m_sentGameMarkedAsEnded;
 
 		std::string matchGuid;
 
@@ -103,6 +100,26 @@ namespace GetgudSDK {
 		}
 
 		return cloneGameData;
+	}
+
+	void GameData::SentGameMarkedAsEnded() {
+
+		m_sentGameMarkedAsEnded = true;
+	}
+
+	void GameData::MarkGameMatchesAsNotInteresting(std::vector<std::string>& matchGuids) {
+
+		std::string matchGuid;
+
+		for (int index = 0; index < matchGuids.size(); index++) {
+			matchGuid = matchGuids[index];
+			auto matchData_it = m_matchMap.find(matchGuid);
+			if (matchData_it == m_matchMap.end())
+				continue;
+
+			matchData_it->second->SetThrottleCheckResults(true, false);
+			logger.Log(LogType::WARN, std::string("Match with the following Guid was marked as Not Interesting: " + matchGuid));
+		}
 	}
 
 	/**
@@ -340,7 +357,8 @@ namespace GetgudSDK {
 	 * GameToString:
 	 *
 	 **/
-	void GameData::GameToString(std::string& gameOut) {
+	void GameData::GameToString(std::string& gameOut, std::vector<std::string>& matchGuids) {
+
 		std::string lastPacket = "false";
 		if (m_isGameMarkedAsEnded == true)
 			lastPacket = "true";
@@ -373,9 +391,10 @@ namespace GetgudSDK {
 				gameOut += matchString;
 				gameOut += ",";
 				containsMatch = true;
+				matchGuids.push_back(matchGuid);
 			}
 		}
-		if (containsMatch || (m_isGameMarkedAsEnded == true)) {
+		if (containsMatch || (m_isGameMarkedAsEnded == true && m_sentGameMarkedAsEnded == false)) {
 			gameOut.pop_back();  // pop the last delimiter
 
 			gameOut += "]}";

--- a/src/game_container/GameData.h
+++ b/src/game_container/GameData.h
@@ -38,6 +38,8 @@ namespace GetgudSDK {
 		void MarkGameAsEnded();
 		bool IsGameMarkedAsEnded();
 		bool DidSendGameMarkedAsEnded();
+		void SentGameMarkedAsEnded();
+		void MarkGameMatchesAsNotInteresting(std::vector<std::string>& matchGuids);
 		MatchData* AddMatch(std::string matchMode, std::string mapName);
 		bool IsGameEligibleForProcessing();
 		GameData* SliceGame(int sizeToSliceInBytes);
@@ -51,7 +53,7 @@ namespace GetgudSDK {
 		std::string GetServerLocation();
 		void GetGameMatchGuids(std::vector<std::string>& matchGuidVectorOut);
 		MatchData* GetGameMatch(std::string matchGuid);
-		void GameToString(std::string& gameOut);
+		void GameToString(std::string& gameOut, std::vector<std::string>& matchGuids);
 		unsigned int GetGameSizeInBytes();
 		unsigned int GetNumberOfGameReportsAndMessages();
 		std::unordered_map<std::string, MatchData*>& GetMatchMap();

--- a/src/senders/game_sender/GameSender.cpp
+++ b/src/senders/game_sender/GameSender.cpp
@@ -110,11 +110,25 @@ namespace GetgudSDK {
 		unsigned gameDataSizeInBytes = gameDataToSend->GetGameSizeInBytes();
 
 		// convert the game to a sendable string and send it to Getgud.io's cloud using curl
-		gameDataToSend->GameToString(gameOut);
+		std::vector<std::string> matchGuids;
+		gameDataToSend->GameToString(gameOut, matchGuids);
 
-		if (!gameOut.empty()) {
+		if (gameOut.empty() == false) {
+
 			logger.Log(LogType::DEBUG, "Sending Game packet for Game guid: " + gameDataToSend->GetGameGuid());
-			SendGamePacket(gameOut);
+
+			if (SendGamePacket(gameOut) == false) {
+
+				// incase failed to send the packet to the server, mark the matches with lost data as not interesting so no other packets will be sent for these matches
+				logger.Log(LogType::WARN, "Failed to send game packet to server, matches with data lose will be marked as Not Interesting for Game guid: " + gameDataToSend->GetGameGuid());
+				gameContainer.MarkGameMatchesAsNotInteresting(gameDataToSend->GetGameGuid(), matchGuids);
+			}
+			else logger.Log(LogType::DEBUG, "Packet for the following Game guid was sent: " + gameDataToSend->GetGameGuid());
+		}
+
+		// check if this is the first time a packet contains the MarkEndGame signal, if so, mark the fact that this signal was sent to the server
+		if (gameDataToSend->IsGameMarkedAsEnded() == true && gameDataToSend->DidSendGameMarkedAsEnded() == false) {
+			gameContainer.SentGameMarkedAsEnded(gameDataToSend->GetGameGuid());
 		}
 
 		// Dispose of the cloned game
@@ -370,9 +384,12 @@ namespace GetgudSDK {
 	 *
 	 * Send game packet with action streams of game matches to Getgud
 	 **/
-	void GameSender::SendGamePacket(std::string& packet) {
+	bool GameSender::SendGamePacket(std::string& packet) {
+		
+		bool retValue = true;
+
 		if (!m_streamCurl || packet.empty()) {
-			return;
+			return retValue;
 		}
 		m_streamCurlReadBuffer.clear();
 		curl_easy_setopt(m_streamCurl, CURLOPT_POSTFIELDS, packet.c_str());
@@ -399,25 +416,27 @@ namespace GetgudSDK {
 		}
 
 		if (sendCode != CURLcode::CURLE_OK) {
+
+			retValue = false;
+
 			if (m_streamCurlReadBuffer.find("\"ErrorType\"") != std::string::npos) {
-				logger.Log(LogType::DEBUG,
-					"GameSender::SendGamePacket->Failed to send throttle request: " +
-					m_streamCurlReadBuffer);
+				logger.Log(LogType::DEBUG,"GameSender::SendGamePacket->Failed to send throttle request: " + m_streamCurlReadBuffer);
 			}
 			else {
-				logger.Log(LogType::_ERROR,
-					"GameSender::SendGamePacket->Failed to send packet: " +
-					std::string(curl_easy_strerror(sendCode)));
+				logger.Log(LogType::_ERROR,"GameSender::SendGamePacket->Failed to send packet: " + std::string(curl_easy_strerror(sendCode)));
 			}
 		}
 		else
 		{
 			if (m_streamCurlReadBuffer.find("\"ErrorType\"") != std::string::npos) {
-				logger.Log(LogType::DEBUG,
-					"GameSender::SendGamePacket->Failed to send throttle request: " +
-					m_streamCurlReadBuffer);
+
+				retValue = false;
+
+				logger.Log(LogType::DEBUG,"GameSender::SendGamePacket->Failed to send throttle request: " + m_streamCurlReadBuffer);
 			}
 		}
+
+		return retValue;
 	}
 
 	/**

--- a/src/senders/game_sender/GameSender.h
+++ b/src/senders/game_sender/GameSender.h
@@ -47,7 +47,7 @@ namespace GetgudSDK {
 		void ManageHyperMode();
 		void ThrottleCheckGameMatches(GameData* gameDataToSend);
 		bool SendThrottleCheckForMatch(std::string& packet);
-		void SendGamePacket(std::string& packet);
+		bool SendGamePacket(std::string& packet);
 		void ReduceMatchActionsSize(GameData* gameDataToSend);
 	};
 }  // namespace GetgudSDK


### PR DESCRIPTION
RECOMMIT:
Improved lost packet logic to include only matches that lost data Unlike prior commit where I marked the entire game as not interesting, this code logic only marks matches that had lost data, thus other matches can still be sent. For this, we had to create 2 new method and a change of logic: 1)  Remove assignment of the original game for the m_sentGameMarkedAsEnded parameter in Clone() 2) Add a new SentGameMarkedAsEnded method logic in the container and Game Data - and use it after trying to send the game packet 3) Add a new MarkGameMatchesAsNotInteresting method logic in the container and Game Data and use it when failing to send a game packet

Mark End Game Fixed bug:
Whenever a mark end game signal is sent to the server - we are now marking it